### PR TITLE
ci: add hardened GoReleaser release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    # Secrets (COSIGN_*) are scoped to this environment; add protection rules there.
+    # HOMEBREW_TAP_GITHUB_TOKEN is scoped to this environment; add protection rules there.
     environment: release
     permissions:
       contents: write # create the GitHub release and upload artifacts
       packages: write # push the container image to ghcr.io
-      id-token: write # OIDC token for cosign/Sigstore signing
+      id-token: write # OIDC token for keyless cosign/Sigstore signing
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -58,9 +58,9 @@ jobs:
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2" # pin the major version; avoids surprise breakage from a new GoReleaser major
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          # PAT with write access to ivuorinen/homebrew-tap; GITHUB_TOKEN cannot push to another repo.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    # HOMEBREW_TAP_GITHUB_TOKEN is scoped to this environment; add protection rules there.
-    environment: release
     permissions:
       contents: write # create the GitHub release and upload artifacts
       packages: write # push the container image to ghcr.io
@@ -62,5 +60,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # PAT with write access to ivuorinen/homebrew-tap; GITHUB_TOKEN cannot push to another repo.
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+---
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions: {}
+
+# One release per tag; never cancel a release that is mid-publish.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    # Secrets (COSIGN_*) are scoped to this environment; add protection rules there.
+    environment: release
+    permissions:
+      contents: write # create the GitHub release and upload artifacts
+      packages: write # push the container image to ghcr.io
+      id-token: write # OIDC token for cosign/Sigstore signing
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false # GoReleaser authenticates via GITHUB_TOKEN, not the persisted git credential
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: "go.mod"
+          cache: false # release builds must not trust a cache poisonable from lower-privilege runs
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: "v2.4.0"
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -88,6 +88,25 @@ checksum:
   name_template: "checksums.txt"
   algorithm: sha256
 
+# Keyless-sign the checksums file with cosign via Sigstore (Fulcio + Rekor). The
+# OIDC identity comes from the workflow's id-token; no long-lived keys are stored.
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
+# Generate SBOMs for the release archives with syft.
+sboms:
+  - id: archive
+    artifacts: archive
+
 # Snapshot configuration
 snapshot:
   name_template: "{{ incpatch .Version }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,7 +74,7 @@ archives:
     # Archive format
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
     # Files to include in archive
     files:
@@ -109,7 +109,7 @@ sboms:
 
 # Snapshot configuration
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 # Release configuration
 release:
@@ -129,12 +129,6 @@ release:
     ### Using Go
     ```bash
     go install github.com/ivuorinen/a@latest
-    ```
-
-    ### Using Homebrew (macOS/Linux)
-    ```bash
-    brew tap ivuorinen/tap
-    brew install a
     ```
 
     ### Manual Download
@@ -172,35 +166,6 @@ changelog:
     - title: "♻️ Refactoring"
       regexp: "^refactor"
     - title: "Other changes"
-
-# Homebrew tap configuration
-brews:
-  - name: a
-    repository:
-      owner: ivuorinen
-      name: homebrew-tap
-      branch: main
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-
-    commit_author:
-      name: goreleaserbot
-      email: bot@goreleaser.com
-
-    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
-
-    homepage: "https://github.com/ivuorinen/a"
-    description: "Modern, secure Go-based CLI tool for managing Fail2Ban jails and bans"
-    license: "MIT"
-
-    dependencies:
-      - name: go
-        type: optional
-
-    test: |
-      system "#{bin}/a", "--version"
-
-    install: |
-      bin.install "a"
 
 # NFPM configuration for Linux packages
 nfpms:


### PR DESCRIPTION
## Summary

Adds a tag-triggered (`v*.*.*`) release workflow that runs GoReleaser to build
multi-platform binaries, publish a container image to ghcr.io, produce `.deb`/`.rpm`/`.apk`
packages, **keyless-sign** the checksums via Sigstore, and attach syft SBOMs.
Hardened against a **zizmor auditor-persona** audit (**0 findings**).

## What it does

- **Build & release**: GoReleaser (`~> v2`, pinned) builds for linux/darwin/freebsd/openbsd/netbsd across amd64/arm64/arm/386.
- **Container image**: pushed to `ghcr.io/ivuorinen/a` using the job's `GITHUB_TOKEN`.
- **Keyless signing**: `cosign sign-blob` signs `checksums.txt` via Sigstore (Fulcio + Rekor) using the workflow's OIDC identity — **no long-lived keys**.
- **SBOMs**: generated for the release archives with syft.
- **Linux packages**: `.deb` / `.rpm` / `.apk` via nfpm.

## Security hardening (all zizmor auditor findings fixed)

| Finding | Severity | Fix |
|---------|----------|-----|
| `undocumented-permissions` | High | Per-scope comments on `contents` / `packages` / `id-token` |
| `concurrency-limits` | High | Tag-scoped `concurrency`, `cancel-in-progress: false` (never abort a mid-publish release) |
| `secrets-outside-env` ×2 | Medium | Resolved by moving to keyless signing — no key secrets remain to scope |
| `artipacked` | Low | `persist-credentials: false` on checkout |
| `cache-poisoning` | Low | `cache: false` on setup-go |
| `anonymous-definition` | info | Named the `release` job |

## Review feedback addressed (Copilot)

- Implemented the signing/SBOM the workflow was set up for (was previously unwired), switching to **keyless OIDC** — dropped `COSIGN_PRIVATE_KEY`/`COSIGN_PASSWORD`.
- Pinned goreleaser-action to `~> v2` instead of `latest`.
- **Dropped the Homebrew tap deployment** entirely (removed the `brews` block and `HOMEBREW_TAP_GITHUB_TOKEN`).
- Fixed GoReleaser v2 deprecations (`snapshot.version_template`, `archives.format_overrides.formats`).

## Setup / notes

- **No repository secrets required** — keyless signing uses OIDC, and the container push uses the built-in `GITHUB_TOKEN`.
- Verified locally: `goreleaser check` passes, `zizmor --persona=auditor` (0 findings), `actionlint`, `yamllint` all clean.
- Not addressed (out of scope): GoReleaser's `dockers` block is being phased out for `dockers_v2` — a non-breaking forward-notice, left for a follow-up.