### PR TITLE
chore(release): migrate docker build to dockers_v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -189,24 +189,25 @@ nfpms:
       - src: ./README.md
         dst: /usr/share/doc/a/README.md
 
-# Docker configuration
-dockers:
-  - image_templates:
-      - "ghcr.io/ivuorinen/a:{{ .Tag }}"
-      - "ghcr.io/ivuorinen/a:v{{ .Major }}"
-      - "ghcr.io/ivuorinen/a:v{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/ivuorinen/a:latest"
-
+# Docker configuration (buildx-based, replaces the deprecated dockers/docker_manifests)
+dockers_v2:
+  - images:
+      - "ghcr.io/ivuorinen/a"
+    tags:
+      - "{{ .Tag }}"
+      - "v{{ .Major }}"
+      - "v{{ .Major }}.{{ .Minor }}"
+      - "latest"
     dockerfile: Dockerfile
-
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--platform=linux/amd64"
+    # ponytail: amd64 only, to match the pre-migration image; add linux/arm64 here to publish a multi-arch manifest (arm64 binaries already build).
+    platforms:
+      - linux/amd64
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.source: "{{ .GitURL }}"
 
 # Announce releases
 announce:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -199,7 +199,7 @@ dockers_v2:
       - "v{{ .Major }}.{{ .Minor }}"
       - "latest"
     dockerfile: Dockerfile
-    # ponytail: amd64 only, to match the pre-migration image; add linux/arm64 here to publish a multi-arch manifest (arm64 binaries already build).
+    # amd64 only, matching the pre-migration image; add linux/arm64 here for a multi-arch manifest (arm64 binaries already build)
     platforms:
       - linux/amd64
     flags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -202,6 +202,8 @@ dockers_v2:
     # ponytail: amd64 only, to match the pre-migration image; add linux/arm64 here to publish a multi-arch manifest (arm64 binaries already build).
     platforms:
       - linux/amd64
+    flags:
+      - "--pull=true" # always refresh the alpine base, matching the old --pull build flag
     labels:
       org.opencontainers.image.created: "{{ .Date }}"
       org.opencontainers.image.title: "{{ .ProjectName }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
-COPY a /usr/local/bin/
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/a /usr/local/bin/
 ENTRYPOINT ["a"]


### PR DESCRIPTION
## Summary
- Migrate the GoReleaser docker pipeline from the deprecated `dockers`/`docker_manifests` to the buildx-based `dockers_v2`
- Restore `--pull=true` so the alpine base is always refreshed, matching the old `--pull` build flag
- Update the Dockerfile to the documented `$TARGETPLATFORM` copy pattern
- Pin cosign to v2.6.3 (v3 broke goreleaser-action's release-bundle verification)

## Verification
- `goreleaser check` passes on GoReleaser v2.16.0
- Full local snapshot release (`goreleaser release --snapshot --clean --skip=sign`) succeeded end-to-end: binaries, archives, deb/rpm/apk, SBOMs, checksums, and the buildx docker build for all four tag templates
- Built image smoke-tested: `docker run … --version` works, correct linux/amd64 arch, all OCI labels stamped

Image stays amd64-only to match the pre-migration release; adding `linux/arm64` to `platforms` is a one-line follow-up if a multi-arch manifest is wanted.